### PR TITLE
don't call BatchStartAware#onBatchStart(0)

### DIFF
--- a/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
+++ b/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
@@ -157,7 +157,7 @@ public final class BatchEventProcessor<T>
             try
             {
                 final long availableSequence = sequenceBarrier.waitFor(nextSequence);
-                if (batchStartAware != null)
+                if (batchStartAware != null && availableSequence >= nextSequence)
                 {
                     batchStartAware.onBatchStart(availableSequence - nextSequence + 1);
                 }


### PR DESCRIPTION
According the WaitStrategy and Sequencer contracts it is possible that SequenceBarrier#waitFor() return without making any progress (happening for MultiProducerSequencer). In that case BatchStartAware#onBatchStart is not expected to be called.
